### PR TITLE
tflite output to handle multiple functions

### DIFF
--- a/narf/tfutils.py
+++ b/narf/tfutils.py
@@ -1,47 +1,62 @@
 import tensorflow as tf
 
-def function_to_tflite(func, input_signature):
+def function_to_tflite(funcs, input_signatures):
     """Convert function to tflite model using python dynamic execution trickery to ensure that inputs
     and outputs are alphabetically ordered, since this is apparently the only way to prevent tflite from
     scrambling them"""
 
-    inputs = []
-    for i in range(len(input_signature)):
-        input_name = f"input_{i:05d}"
-        inputs.append(input_name)
+    if not isinstance(funcs, list):
+        funcs = [funcs]
+        input_signatures = [input_signatures]
 
-    def wrapped_func(*args):
-        outputs = func(*args)
+    def wrapped_func(iif, *args):
+        outputs = funcs[iif](*args)
 
         if not isinstance(outputs, tuple):
             outputs = (outputs,)
 
         output_dict = {}
         for i,output in enumerate(outputs):
-            output_name = f"output_{i:05d}"
+            output_name = f"output_{iif:05d}_{i:05d}"
             output_dict[output_name] = output
 
         return output_dict
 
-    arg_string = ", ".join(inputs)
+    arg_string = []
+    for iif, input_signature in enumerate(input_signatures):
+        inputs = []
+        if input_signature == None or input_signature == "":
+            inputs.append("")
+        else:
+            for i in range(len(input_signature)):
+                input_name = f"input_{iif:05d}_{i:05d}"
+                inputs.append(input_name)
+        arg_string.append(", ".join(inputs))
 
     def_string = ""
-    def_string += "def make_module(wrapped_func, input_signature):\n"
+    def_string += "def make_module(wrapped_func, input_signatures):\n"
     def_string += "    class Export_Module(tf.Module):\n"
-    def_string += "        @tf.function(input_signature = input_signature)\n"
-    def_string += f"        def __call__(self, {arg_string}):\n"
-    def_string += f"            return wrapped_func({arg_string})\n"
+    for i, func in enumerate(funcs):
+        if arg_string[i] == "":
+            def_string += f"        @tf.function()\n"
+            def_string += f"        def {func.__name__}(self):\n"
+            def_string += f"            return wrapped_func({i})\n"
+        else:
+            def_string += f"        @tf.function(input_signature = input_signatures[{i}])\n"
+            def_string += f"        def {func.__name__}(self, {arg_string[i]}):\n"
+            def_string += f"            return wrapped_func({i}, {arg_string[i]})\n"
     def_string += "    return Export_Module"
 
     ldict = {}
     exec(def_string, globals(), ldict)
 
     make_module = ldict["make_module"]
-    Export_Module = make_module(wrapped_func, input_signature)
+    Export_Module = make_module(wrapped_func, input_signatures)
 
     module = Export_Module()
-    concrete_function = module.__call__.get_concrete_function()
-    converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_function], module)
+    #concrete_function = module.__call__.get_concrete_function()
+    concrete_functions = [getattr(module, func_name).get_concrete_function() for func_name in [f.__name__ for f in funcs]]
+    converter = tf.lite.TFLiteConverter.from_concrete_functions(concrete_functions, module)
 
     # enable TenorFlow ops and DISABLE builtin TFLite ops since these apparently slow things down
     converter.target_spec.supported_ops = [


### PR DESCRIPTION
Can take a list of functions and input signatures. 

If a single function is provided, the name of the signature runner is serving_default. If more than one function is provided, the names of the signatures are equal to the names of the input Python functions (__name__).

Inputs and outputs have unique/ordered names by adding the function index to their names