### PR TITLE
Add Bin by bin stat uncertainty to variances

### DIFF
--- a/narf/combineutils.py
+++ b/narf/combineutils.py
@@ -244,6 +244,9 @@ class Fitter:
         RJ = t1.jacobian(RJu, u)
         sRJ2 = tf.reduce_sum(RJ**2, axis=0)
         sRJ2 = tf.reshape(sRJ2, expected.shape)
+        # add MC stat uncertainty on variance
+        sumw2 = tf.square(expected)/self.indata.kstat
+        sRJ2 = sRJ2 + sumw2
         return expected, sRJ2
 
     def _chi2_pedantic(self, fun_exp, observed, invhess):
@@ -261,7 +264,10 @@ class Fitter:
         K = J @invhess @ tf.transpose(J)
         # add data uncertainty on covariance
         K = K + tf.linalg.diag(observed)
-
+        # add MC stat uncertainty on covariance
+        sumw2 = tf.square(expected)/self.indata.kstat
+        K = K + tf.linalg.diag(sumw2)
+        
         Kinv = tf.linalg.inv(K)
 
         # chi2 = uT*Kinv*u
@@ -282,6 +288,10 @@ class Fitter:
 
         err = tf.linalg.diag_part(cov)
         err = tf.reshape(err, expected.shape)
+
+        # add MC stat uncertainty on variance
+        sumw2 = tf.square(expected)/self.indata.kstat
+        err = err + sumw2
 
         return expected, err
 

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -21,7 +21,7 @@ parser.add_argument("--allowNegativePOI", default=False, action='store_true', he
 parser.add_argument("--POIDefault", default=1., type=float, help="mode for POI's")
 parser.add_argument("--saveHists", default=False, action='store_true', help="save prefit and postfit histograms")
 parser.add_argument("--computeHistErrors", default=False, action='store_true', help="propagate uncertainties to prefit and postfit histograms")
-parser.add_argument("--binByBinStat", default=False, action='store_true', help="add bin-by-bin statistical uncertainties on templates (using Barlow and Beeston 'lite' method")
+parser.add_argument("--binByBinStat", default=False, action='store_true', help="add bin-by-bin statistical uncertainties on templates (adding sumW2 on variance)")
 parser.add_argument("--externalPostfit", default=None, help="load posfit nuisance parameters and covariance from result of an external fit")
 
 args = parser.parse_args()


### PR DESCRIPTION
The BBB variance is assumed to be sumw2 of the prediction. Sumw2 is obtained from the expected yield and kstat tensors by sumw2=expected**2/kstat. The sumw2 is added to the covariance matrix for the chi2 computation and to the variances when calculating the variances with respect to the bins (for prefit and postfit bands). 