### PR TITLE
Add script metadata for combinetf2

### DIFF
--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -162,6 +162,7 @@ if args.saveHists:
 
 # pass meta data into output file
 meta = {
+    "meta_info_combinetf2" : narf.ioutils.make_meta_info_dict(args=args),
     "signals": fitter.indata.signals,
     "procs": fitter.indata.procs,
     **fitter.indata.metadata


### PR DESCRIPTION
Save metadata when running combinetf2 (script command, arguments, and git hash/diff) to keep track of chain of command and changes. Therefore, the helper functions "metaInfoDict" and "script_command_to_str" are moved from WRemnants/utilities/ioutils.py to narf/ioutils.py