### PR TITLE
Improve counting ndf

### DIFF
--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -95,7 +95,8 @@ if args.externalPostfit is not None:
 chi2_postfit = fitter.chi2(cov)
 
 results = {
-    "ndf": fitter.indata.nbins - fitter.indata.nnoigroups - fitter.indata.nsignals,
+    "ndf_prefit": fitter.indata.nbins,
+    "ndf_postfit": fitter.indata.nbins - fitter.indata.nsystnoconstraint - fitter.indata.nsignals,
     "chi2_prefit": chi2_prefit,
     "chi2_postfit": chi2_postfit
 }


### PR DESCRIPTION
Currently the ndf is incorrect for prefit chisquared, because here the number of free parameters should not be subtracted.

For the postfit case the counting is also made more robust, since the subtraction should be done for unconstrained parameters irrespective of whether or not they are defined in noi groups. 