### PR TITLE
Adding nuisance parameter impacts

### DIFF
--- a/narf/combineutils.py
+++ b/narf/combineutils.py
@@ -480,8 +480,6 @@ class Fitter:
 
         impacts = cov[:nstat,:]
 
-        systgroupidxs = tf.ragged.constant(self.indata.systgroupidxs, dtype=tf.int32)
-
         impacts_grouped = tf.concat([
             self._compute_impact_group(cov, nstat, idxs)
             for idxs in self.indata.systgroupidxs
@@ -573,9 +571,6 @@ class Fitter:
 
         dxdtheta0, dxdnobs, dxdbeta0 = self._global_impacts(cov)
         
-        # group grobal impacts
-        systgroupidxs = tf.ragged.constant(self.indata.systgroupidxs, dtype=tf.int32)
-
         impacts_grouped = tf.concat([
             self._compute_global_impact_group(dxdtheta0, idxs)
             for idxs in self.indata.systgroupidxs

--- a/narf/combineutils.py
+++ b/narf/combineutils.py
@@ -815,7 +815,7 @@ class Fitter:
         return nexpfull, normfull, beta
 
     def _compute_yields(self, inclusive=True, profile=True, profile_grad=True):
-        nexpfullcentral, normfullcentral, beta = self._compute_yields_with_beta(profile=profile, profile_grad=profile_grad, compute_normfull=inclusive)
+        nexpfullcentral, normfullcentral, beta = self._compute_yields_with_beta(profile=profile, profile_grad=profile_grad, compute_normfull=not inclusive)
         if inclusive:
             return nexpfullcentral
         else:
@@ -889,13 +889,12 @@ class Fitter:
             chi2val = self.chi2(res, rescov).numpy()
             ndf = tf.size(exp).numpy() - self.normalize
 
-            # copy axes and rename
-            hist_axes_y = copy.deepcopy(hist_axes)
-            for a in hist_axes_y:
-                a.__dict__["name"] = a.name+"_y"
+            # flat axes for covariance matrix, since it can go across channels
+            flat_axis_x = hist.axis.Integer(0, rescov.shape[0], underflow=False, overflow=False, name="x")
+            flat_axis_y = hist.axis.Integer(0, rescov.shape[1], underflow=False, overflow=False, name="y")
 
-            h_rescov = hist.Hist(*hist_axes, *hist_axes_y, storage=hist.storage.Double(), name=f"{name}_cov", label=f"{label} covariance")
-            h_rescov.values()[...] = memoryview(tf.reshape(rescov, h_rescov.shape))
+            h_rescov = hist.Hist(flat_axis_x, flat_axis_y, storage=hist.storage.Double(), name=f"{name}_cov", label=f"{label} covariance")
+            h_rescov.values()[...] = memoryview(rescov)
             h_rescov = narf.ioutils.H5PickleProxy(h_rescov)
 
             return hists, h_rescov, chi2val, ndf
@@ -990,13 +989,12 @@ class Fitter:
             chi2val = self.chi2(res, rescov).numpy()
             ndf = tf.size(exp).numpy() - self.normalize
 
-            # copy axes and rename
-            hist_axes_y = copy.deepcopy(hist_axes)
-            for a in hist_axes_y:
-                a.__dict__["name"] = a.name+"_y"
+            # flat axes for covariance matrix, since it can go across channels
+            flat_axis_x = hist.axis.Integer(0, rescov.shape[0], underflow=False, overflow=False, name="x")
+            flat_axis_y = hist.axis.Integer(0, rescov.shape[1], underflow=False, overflow=False, name="y")
 
-            h_rescov = hist.Hist(*hist_axes, *hist_axes_y, storage=hist.storage.Double(), name=f"{name}_cov", label=f"{label} covariance")
-            h_rescov.values()[...] = memoryview(tf.reshape(rescov, h_rescov.shape))
+            h_rescov = hist.Hist(flat_axis_x, flat_axis_y, storage=hist.storage.Double(), name=f"{name}_cov", label=f"{label} covariance")
+            h_rescov.values()[...] = memoryview(rescov)
             h_rescov = narf.ioutils.H5PickleProxy(h_rescov)
 
             return h, h_rescov, chi2val, ndf

--- a/narf/combineutils.py
+++ b/narf/combineutils.py
@@ -408,9 +408,9 @@ class Fitter:
                 self.data_cov = self.indata.data_cov
             else:
                 # covariance from data stat
-                if any(self.nobs<=0):
+                if tf.math.reduce_any(self.nobs <= 0).numpy():
                     raise RuntimeError("Bins in 'nobs <= 0' encountered, chi^2 fit can not be performed.")
-                self.data_cov = tf.diag(self.nobs)
+                self.data_cov = tf.linalg.diag(self.nobs)
 
         # constraint minima for nuisance parameters
         self.theta0 = tf.Variable(tf.zeros([self.indata.nsyst],dtype=self.indata.dtype), trainable=False, name="theta0")

--- a/narf/combineutils.py
+++ b/narf/combineutils.py
@@ -333,7 +333,7 @@ class FitDebugData:
         return nonzero_procs
 
 
-class Fitresult:
+class Workspace:
     def __init__(self, output_format="narf"):
         self.output_format = output_format
 
@@ -375,7 +375,7 @@ class Fitresult:
 
 
 class Fitter:
-    def __init__(self, indata, options, fitresult=None):
+    def __init__(self, indata, options, workspace=None):
         self.indata = indata
         self.binByBinStat = options.binByBinStat
         self.normalize = options.normalize
@@ -449,8 +449,8 @@ class Fitter:
         nexpfullcentral = self.expected_events(profile=False)
         self.nexpnom = tf.Variable(nexpfullcentral, trainable=False, name="nexpnom")
 
-        self.fitresult = Fitresult() if fitresult is None else fitresult
-        self.hist = self.fitresult.hist
+        self.workspace = Workspace() if workspace is None else workspace
+        self.hist = self.workspace.hist
 
     def prefit_covariance(self, unconstrained_err=0.):
         # free parameters are taken to have zero uncertainty for the purposes of prefit uncertainties
@@ -560,7 +560,7 @@ class Fitter:
         axis_impacts_grouped = self.indata.getImpactsAxesGrouped(self.binByBinStat)
 
         h = self.hist("impacts", [axis_parms, axis_impacts], values=impacts)
-        h_grouped = self.hist("impacts_grouped", [axis_parms, axis_impacts_groupe], values=impacts_grouped)
+        h_grouped = self.hist("impacts_grouped", [axis_parms, axis_impacts_grouped], values=impacts_grouped)
 
         return h, h_grouped
 

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -179,6 +179,10 @@ results.update({
 
 if args.doImpacts:
 
+    h_pulls, h_constrains = fitter.pulls_and_constraints(cov)
+    results["pulls"] = h_pulls
+    results["constraints"] = h_constrains
+
     if args.globalImpacts:
 
         h, h_grouped = fitter.global_impacts(cov)

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -68,7 +68,7 @@ if args.saveHists:
         projection.update({"hist_data_obs" : hist_data_obs,
                     "hist_nobs" : hist_nobs,})
 
-    print(f"Save - inclusive")
+    print(f"Save - inclusive hist")
 
     hist_prefit_inclusive, aux_info = fitter.expected_hists(
         cov_prefit, 
@@ -81,7 +81,7 @@ if args.saveHists:
         label = "prefit expected number of events for all processes combined",
         )
 
-    print(f"Save - processes")
+    print(f"Save - processes hist")
 
     hist_prefit = fitter.expected_hists(
         cov_prefit, 
@@ -249,7 +249,7 @@ if args.doImpacts:
 if args.saveHists:
     print("Save postfit hists")
 
-    print(f"Save - inclusive")
+    print(f"Save - inclusive hist")
 
     hist_postfit_inclusive, aux_info = fitter.expected_hists(
         cov, 
@@ -264,7 +264,7 @@ if args.saveHists:
         label = "postfit expected number of events for all processes combined",
         )
 
-    print(f"Save - processes")
+    print(f"Save - processes hist")
 
     hist_postfit = fitter.expected_hists(
         cov, 
@@ -408,6 +408,5 @@ meta = {
     "signals": fitter.indata.signals,
     "procs": fitter.indata.procs,
 }
-
 
 fitter.workspace.write(args.output, results, meta)

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -66,7 +66,7 @@ if args.saveHists:
         projection.update({"hist_data_obs" : hist_data_obs,
                     "hist_nobs" : hist_nobs,})
 
-    hist_prefit_inclusive, chi2_prefit, ndf_prefit = fitter.expected_hists(cov_prefit, inclusive=True, profile=False, compute_variance=args.computeHistErrors, compute_chi2=True, name = "prefit_inclusive", label = "prefit expected number of events for all processes combined")
+    hist_prefit_inclusive, hist_cov_postfit_inclusive, chi2_prefit, ndf_prefit = fitter.expected_hists(cov_prefit, inclusive=True, profile=False, compute_variance=args.computeHistErrors, compute_chi2=True, name = "prefit_inclusive", label = "prefit expected number of events for all processes combined")
 
     hist_prefit = fitter.expected_hists(cov_prefit, inclusive=False, profile=False, compute_variance=args.computeHistErrors, name = "prefit", label = "prefit expected number of events")
 
@@ -83,7 +83,7 @@ if args.saveHists:
 
         axes_str = "-".join(axes)
 
-        hist_prefit_inclusive, chi2_prefit, ndf_prefit = fitter.expected_projection_hist(cov=cov_prefit, channel=channel, axes=axes, inclusive=True, profile=False, compute_variance=args.computeHistErrors, compute_chi2=True, name=f"prefit_inclusive_projection_{channel}_{axes_str}", label=f"prefit expected number of events for all processes combined, projection for channel {channel} and axes {axes_str}.")
+        hist_prefit_inclusive, hist_cov_postfit_inclusive, chi2_prefit, ndf_prefit = fitter.expected_projection_hist(cov=cov_prefit, channel=channel, axes=axes, inclusive=True, profile=False, compute_variance=args.computeHistErrors, compute_chi2=True, name=f"prefit_inclusive_projection_{channel}_{axes_str}", label=f"prefit expected number of events for all processes combined, projection for channel {channel} and axes {axes_str}.")
 
         hist_prefit = fitter.expected_projection_hist(cov=cov_prefit, channel=channel, axes=axes, inclusive=False, profile=False, compute_variance=args.computeHistErrors, name=f"prefit_projection_{channel}_{axes_str}", label=f"prefit expected number of events, projection for channel {channel} and axes {axes_str}.")
 
@@ -201,12 +201,15 @@ if args.doImpacts:
 
 if args.saveHists:
 
-    hist_postfit_inclusive, chi2_postfit, ndf_postfit = fitter.expected_hists(cov, inclusive=True, profile=postfit_profile, compute_variance=args.computeHistErrors, compute_chi2=True, name = "postfit_inclusive", label = "postfit expected number of events for all processes combined")
+    hist_postfit_inclusive, hist_cov_postfit_inclusive, chi2_postfit, ndf_postfit = fitter.expected_hists(
+        cov, inclusive=True, profile=postfit_profile, compute_variance=args.computeHistErrors, compute_chi2=True, hist_cov=True,
+        name = "postfit_inclusive", label = "postfit expected number of events for all processes combined")
 
     hist_postfit = fitter.expected_hists(cov, inclusive=False, profile=postfit_profile, compute_variance=args.computeHistErrors, name = "postfit", label = "postfit expected number of events")
 
     results.update({
         "hist_postfit_inclusive" : hist_postfit_inclusive,
+        "hist_cov_postfit_inclusive" : hist_cov_postfit_inclusive,
         "hist_postfit" : hist_postfit,
         "ndf_postfit": ndf_postfit,
         "chi2_postfit": chi2_postfit,
@@ -218,12 +221,15 @@ if args.saveHists:
 
         axes_str = "-".join(axes)
 
-        hist_postfit_inclusive, chi2_postfit, ndf_postfit = fitter.expected_projection_hist(cov=cov, channel=channel, axes=axes, inclusive=True, profile=postfit_profile, compute_variance=args.computeHistErrors, compute_chi2=True, name=f"postfit_inclusive_projection_{channel}_{axes_str}", label=f"postfit expected number of events for all processes combined, projection for channel {channel} and axes {axes_str}.")
+        hist_postfit_inclusive, hist_cov_postfit_inclusive, chi2_postfit, ndf_postfit = fitter.expected_projection_hist(
+            cov=cov, channel=channel, axes=axes, inclusive=True, profile=postfit_profile, compute_variance=args.computeHistErrors, compute_chi2=True, hist_cov=True,
+            name=f"postfit_inclusive_projection_{channel}_{axes_str}", label=f"postfit expected number of events for all processes combined, projection for channel {channel} and axes {axes_str}.")
 
         hist_postfit = fitter.expected_projection_hist(cov=cov, channel=channel, axes=axes, inclusive=False, profile=postfit_profile, compute_variance=args.computeHistErrors, name=f"postfit_projection_{channel}_{axes_str}", label=f"postfit expected number of events, projection for channel {channel} and axes {axes_str}.")
 
         projection.update({
             "hist_postfit_inclusive" : hist_postfit_inclusive,
+            "hist_cov_postfit_inclusive" : hist_cov_postfit_inclusive,
             "hist_postfit" : hist_postfit,
             "ndf_postfit": ndf_postfit,
             "chi2_postfit": chi2_postfit,

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -42,14 +42,10 @@ if args.toys == -1:
 
 cov_prefit = fitter.prefit_covariance()
 
-results = {}
-
-results["projections"] = []
-for projection in args.project:
-    channel = projection[0]
-    axes = projection[1:]
-
-    results["projections"].append({"channel" : channel, "axes" : axes})
+results = {
+    "parms_prefit": fitter.parms_hist(cov_prefit, hist_name="prefit"),
+    "projections": [{"channel": projection[0], "axes": projection[1:]} for projection in args.project],
+}
 
 if args.saveHists:
 
@@ -132,7 +128,7 @@ if args.externalPostfit is not None:
         if "x" in fext.keys():
             # fitresult from combinetf 1
             x_ext = fext["x"][...]
-            parms_ext = fext["parms"][...]
+            parms_ext = fext["parms"][...].astype(str)
             cov_ext = fext["cov"][...]
         else:
             # fitresult from combinetf 2
@@ -150,7 +146,8 @@ if args.externalPostfit is not None:
 
     parmmap = {}
 
-    for iparm, parm in enumerate(fitter.parms):
+    parms = fitter.parms.astype(str)
+    for iparm, parm in enumerate(parms):
         parmmap[parm] = iparm
 
     for iparm_ext, parmi_ext in enumerate(parms_ext):
@@ -181,16 +178,13 @@ satnllvalfull, ndfsat = fitter.saturated_nll()
 satnllvalfull = satnllvalfull.numpy()
 ndfsat = ndfsat.numpy()
 
-h_parms, h_parms_prefit = fitter.parms_hist(cov)
-
 results.update({
     "nllvalfull" : nllvalfull,
     "satnllvalfull" : satnllvalfull,
     "ndfsat" : ndfsat,
     "postfit_profile" : postfit_profile,
     "cov": fitter.cov_hist(cov),
-    "parms": h_parms,
-    "parms_prefit": h_parms_prefit,
+    "parms": fitter.parms_hist(cov),
 })
 
 if args.doImpacts:

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -38,8 +38,8 @@ parser.add_argument("--externalCovariance", default=False, action='store_true', 
 args = parser.parse_args()
 
 indata = narf.combineutils.FitInputData(args.filename, args.pseudoData)
-fitresult = narf.combineutils.Fitresult(args.outputFormat)
-fitter = narf.combineutils.Fitter(indata, args, fitresult)
+workspace = narf.combineutils.Workspace(args.outputFormat)
+fitter = narf.combineutils.Fitter(indata, args, workspace)
 
 if args.toys == -1:
     fitter.nobs.assign(fitter.expected_events(profile=False))
@@ -62,8 +62,8 @@ if args.saveHists:
         channel = projection["channel"]
         axes = projection["axes"]
 
-        hist_data_obs = fitter.fitresult.project(results["hist_data_obs"][channel], axes)
-        hist_nobs = fitter.fitresult.project(results["hist_nobs"][channel], axes)
+        hist_data_obs = fitter.workspace.project(results["hist_data_obs"][channel], axes)
+        hist_nobs = fitter.workspace.project(results["hist_nobs"][channel], axes)
 
         projection.update({"hist_data_obs" : hist_data_obs,
                     "hist_nobs" : hist_nobs,})
@@ -138,9 +138,9 @@ if args.saveHists:
             "hist_prefit_inclusive" : hist_prefit_inclusive,
             "hist_prefit" : hist_prefit
         })
-    if not args.noChi2:
-        projection["ndf_prefit"] = aux_info["ndf"]
-        projection["chi2_prefit"] = aux_info["chi2"]
+        if not args.noChi2:
+            projection["ndf_prefit"] = aux_info["ndf"]
+            projection["chi2_prefit"] = aux_info["chi2"]
 
     if args.computeVariations:
         cov_prefit_variations = fitter.prefit_covariance(unconstrained_err=1.)
@@ -410,4 +410,4 @@ meta = {
 }
 
 
-fitter.fitresult.write(args.output, results, meta)
+fitter.workspace.write(args.output, results, meta)

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -113,14 +113,6 @@ if args.saveHists:
 
         del cov_prefit_variations
 
-dofit = args.toys >= 0 and args.externalPostfit is None
-
-if dofit:
-    fitter.minimize()
-
-val, grad, hess = fitter.loss_val_grad_hess()
-
-cov = tf.linalg.inv(hess)
 
 if args.externalPostfit is not None:
     # load results from external fit and set postfit value and covariance elements for common parameters
@@ -167,8 +159,15 @@ if args.externalPostfit is not None:
             covval[iparm, jparm] = cov_ext[iparm_ext, jparm_ext]
 
     fitter.x.assign(xvals)
-    cov = tf.convert_to_tensor(covval)
+    cov = tf.convert_to_tensor(covval)    
+else:
+    dofit = args.toys >= 0
 
+    if dofit:
+        fitter.minimize()
+
+    val, grad, hess = fitter.loss_val_grad_hess()
+    cov = tf.linalg.inv(hess)
 
 postfit_profile = args.externalPostfit is None
 

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -179,13 +179,17 @@ results.update({
 
 if args.doImpacts:
 
-    h_pulls, h_constrains = fitter.pulls_and_constraints(cov)
+    h_pulls, h_constraints = fitter.pulls_and_constraints(cov)
     results["pulls"] = h_pulls
-    results["constraints"] = h_constrains
+    results["constraints"] = h_constraints
+
+    h, h_grouped = fitter.impacts_systs(cov, hess)
+    results["impacts"] = h
+    results["impacts_grouped"] = h_grouped
 
     if args.globalImpacts:
 
-        h, h_grouped = fitter.global_impacts(cov)
+        h, h_grouped = fitter.global_impacts_systs(cov)
 
         results["global_impacts"] = h
         results["global_impacts_grouped"] = h_grouped

--- a/scripts/fitting/combinetf2.py
+++ b/scripts/fitting/combinetf2.py
@@ -27,6 +27,8 @@ parser.add_argument("--externalPostfit", default=None, help="load posfit nuisanc
 parser.add_argument("--pseudoData", default=None, type=str, help="run fit on pseudo data with the given name")
 parser.add_argument("--normalize", default=False, action='store_true', help="Normalize prediction and systematic uncertainties to the overall event yield in data")
 parser.add_argument("--project", nargs="+", action="append", default=[], help="add projection for the prefit and postfit histograms, specifying the channel name followed by the axis names, e.g. \"--project ch0 eta pt\".  This argument can be called multiple times")
+parser.add_argument("--doImpacts", default=False, action='store_true', help="Compute impacts on POIs per nuisance parameter and per-nuisance parameter group")
+parser.add_argument("--globalImpacts", default = False, action='store_true', help="compute impacts in terms of variations of global observables (as opposed to nuisance parameters directly)")
 
 args = parser.parse_args()
 
@@ -174,6 +176,15 @@ results.update({
     "ndfsat" : ndfsat,
     "postfit_profile" : postfit_profile,
 })
+
+if args.doImpacts:
+
+    if args.globalImpacts:
+
+        h, h_grouped = fitter.global_impacts(cov)
+
+        results["global_impacts"] = h
+        results["global_impacts_grouped"] = h_grouped
 
 if args.saveHists:
 


### PR DESCRIPTION
- (nuisance) parameter pulls and constraints
- global and traditional (grouped) impacts
- Implement sparse mode (but very slow, not sure if it can be improved)
- Implement global impacts on observables (the non-profile case is wrong)
- Write out additional information such as covariance on observable e.g. for unfolded cross sections
- Add option to skip chi2 calculation
- factorize functionality to save and write histograms to better toggle to other formats (in the future)