### PR TITLE
Make narf/ioutils pip installable from single file within narf

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+# Include specific files or directories
+exclude narf/*
+exclude datasets/*
+exclude scripts/fitting/*
+exclude scripts/test/*
+
+include narf/ioutils.py
+include doc/ioutils.md

--- a/doc/ioutils.md
+++ b/doc/ioutils.md
@@ -1,0 +1,1 @@
+# narf-ioutils

--- a/narf/ioutils.py
+++ b/narf/ioutils.py
@@ -12,7 +12,7 @@ import datetime
 import subprocess
 import os, sys
 import re
-from narf import common
+import pathlib
 
 MIN_PROTOCOL_VERSION = 1
 CURRENT_PROTOCOL_VERSION = 1
@@ -319,7 +319,7 @@ def script_command_to_str(argv, parser_args):
             call_args[select] = np.vectorize(lambda x: f"'{x}'")(call_args[select])
     return " ".join([argv[0], *call_args])
 
-def make_meta_info_dict(exclude_diff = 'notebooks', args = None, wd = common.base_dir):
+def make_meta_info_dict(exclude_diff = 'notebooks', args = None, wd = f"{pathlib.Path(__file__).parent}/../"):
     meta_data = {
         "time" : str(datetime.datetime.now()), 
         "command" : script_command_to_str(sys.argv, args),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "narf-ioutils"
+version = "0.1.4"
+description = "Storage of objects in h5py files with lazy reading."
+readme = { file = "doc/ioutils.md", content-type = "text/markdown" }
+license = { text = "MIT" }
+authors = [
+    {name = "Josh Bendavid", email = "josh.bendavid@cern.ch"},
+    {name = "Kenneth Long", email = "kenneth.long@cern.ch"},
+    {name = "David Walter", email = "david.walter@cern.ch"}
+]
+urls = {Homepage = "https://github.com/bendavid/narf"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
+]
+requires-python = ">=3.8"
+
+dependencies = [
+    "boost-histogram>=1.3.2",
+    "h5py>=3.0.0",
+    "hdf5plugin>=3.4.0",
+    "hist>=2.6.0",  
+    "numpy>=1.19.0"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
The ioutils are required if someone wants to run combinetf2 as a standalone tool. 
This PR contains the changes and new files to make the ioutils a pip installable pypi project that can be found under https://pypi.org/project/narf-ioutils/0.1.4/

This would be a replacement for https://github.com/wmass/ioutils and allows for more flexibility to either use/develop the ioutils from narf HEAD or use the stable pypi version, in both cases the import paths are the same